### PR TITLE
setupHooks pre node v6 / starting with node v6

### DIFF
--- a/docs/AsyncWrap/README.md
+++ b/docs/AsyncWrap/README.md
@@ -252,7 +252,10 @@ A classic use case for AsyncWrap is to create a long-stack-trace tool.
 ```javascript
 const asyncWrap = process.binding('async_wrap');
 
+// bevore node version 6
 asyncWrap.setupHooks(init, before, after, destroy);
+// starting with node version 6
+asyncWrap.setupHooks({init, before, after, destroy});
 asyncWrap.enable();
 
 // global state variable, that contains the stack traces and the current uid


### PR DESCRIPTION
as of https://github.com/nodejs/node/blob/a20c70029075cab18e4ff4d27dfd95b7eda2b268/test/parallel/test-async-wrap-uid.js#L9

starting with node version 6, you have to pass an object